### PR TITLE
Update mysql-query.js

### DIFF
--- a/lib/mysql-query.js
+++ b/lib/mysql-query.js
@@ -30,7 +30,9 @@ function query(/* args, [connection_name,] callback */) {
       }
 
       args.push(function (/* err, ... results */) {
-        if (connection.release) {
+        if (process.env.NODE_ENV === 'test') {
+          connection.destroy();
+        } else if (connection.release) {
           connection.release();
         } else {
           connection.end();


### PR DESCRIPTION
On tests like Jest, opened pool connection leads to unclosed each test where using mysql query. I'm not sure it's best solution, but it works, just destroy connection in 'test' enveronment.